### PR TITLE
Fix getting Registry Value for JPHP 1.0.3 (7.1.99)

### DIFF
--- a/package.php.yml
+++ b/package.php.yml
@@ -36,7 +36,7 @@ config:
   - /gradlew.**
 
 develnext-bundle:
-  version: 2.2
+  version: 2.3
   name: windows
   description: Плагин для взаимодействия с API Windows
   author: Ts.Saltan

--- a/package.php.yml
+++ b/package.php.yml
@@ -1,5 +1,5 @@
 name: windows
-version: 2.2
+version: 2.3
 description: Пакет для взаимодействия с API Windows
 
 plugins:

--- a/package.php.yml
+++ b/package.php.yml
@@ -1,5 +1,5 @@
 name: windows
-version: 2.3
+version: 2.4
 description: Пакет для взаимодействия с API Windows
 
 plugins:

--- a/src/bundle/windows/Registry.php
+++ b/src/bundle/windows/Registry.php
@@ -89,17 +89,18 @@ class Registry
         $exec = $this->query('query ":path"' . ($recursive ? ' /s' : ''), ['path' => $this->path]);
         return $this->parseAnswer($exec);
     }
-    
+
     /**
      * --RU--
      * Чтение ключа
      * @param string $key имя ключа
-     * @return registryItem
+     * @return registryItem|null
      */
-    public function read($key){
+    public function read($key) {
         $exec = $this->query('query ":path" /v ":key"', ['path' => $this->path, 'key' => $key]);
-        $result = $this->parseAnswer($exec);
-        return isset($result[0]) ? $result[0]->next() : null;
+        $answer = $this->parseAnswer($exec);
+
+        return isset($answer[0]) ? $answer[0]->current() : null; // fix ->next() to ->current() for JPHP 1.0.3 (7.1.99)
     }
     
     /**
@@ -178,6 +179,12 @@ class Registry
         return $this->parseAnswer($exec);
     }
 
+    /**
+     * -- RU --
+     * Чтение результата выполнения запроса в реестр
+     * @param $answer Ответ запроса в реестр
+     * @return registryResult[]
+     */
     private function parseAnswer($answer){
         $parts = explode("\nHKEY_", $answer);      
         $return = [];

--- a/src/bundle/windows/Windows.php
+++ b/src/bundle/windows/Windows.php
@@ -955,7 +955,7 @@ PS;
         $windows = self::getWindowsPath();
         return fs::exists("$windows\\SysNative\\$path") 
                 ? "$windows\\SysNative\\$path" 
-                : self::getSystem32Path();
+                : self::getSystem32($path);
     }
 
     /**

--- a/src/bundle/windows/Windows.php
+++ b/src/bundle/windows/Windows.php
@@ -906,20 +906,39 @@ PS;
     }
 
     /**
-     * Путь к системной папке windows\system32
+     * Путь к файлу папке windows\system32
      *  
      * @return string
      */
     public static function getSystem32($path) : string {
-        return self::getSystemDrive() . ':\\Windows\\System32\\' . $path;
+        $path = self::getSystem32Path() . $path;
+        return fs::exists($path) ? $path : null;
+    }
+
+    /**
+     * Путь к системной папке windows\system32
+     *  
+     * @return string
+     */
+    public static function getSystem32path(): string {
+      return self::getWindowsPath() . '\\System32\\';
     }   
+
+    /**
+     * Путь к папке, где установлена Windows
+     * 
+     * @return string
+     */
+    public static function getWindowsPath() : string {
+      return $_ENV['WinDir'] ?? $_ENV['SystemRoot'] ?? 'C:\\Windows';
+    }
 
     /**
      * Возвращает букву системного диска 
      * @return string
      */
     public static function getSystemDrive() : string {
-        $path = $_ENV['HOMEDRIVE'] ?? $_ENV['SystemRoot'] ?? 'C';
+        $path = $_ENV['SystemDrive'] ?? $_ENV['SystemRoot'] ?? $_ENV['HOMEDRIVE'] ?? 'C';
         return str::sub($path, 0, 1);
     }    
 
@@ -933,9 +952,10 @@ PS;
      * @todo test on win7
      */
     public static function getSysNative($path) : string {
-        return fs::exists(self::getSystemDrive() . ':\\Windows\\SysNative\\' . $path) 
-                ? (self::getSystemDrive() . ':\\Windows\\SysNative\\' . $path) 
-                : (self::getSystemDrive() . ':\\Windows\\System32\\' . $path);
+        $windows = self::getWindowsPath();
+        return fs::exists("$windows\\SysNative\\$path") 
+                ? "$windows\\SysNative\\$path" 
+                : self::getSystem32Path();
     }
 
     /**


### PR DESCRIPTION
Old JPHP returns first array key after execution of next() function, but new JPHP version fixes this issue;